### PR TITLE
Add Databook and Logibook to World/indicators

### DIFF
--- a/data/entities/World/indicators/databookdataintnet.yaml
+++ b/data/entities/World/indicators/databookdataintnet.yaml
@@ -1,0 +1,94 @@
+access_mode:
+- open
+api: false
+api_status: uncertain
+catalog_type: Indicators catalog
+content_types:
+- indicator
+coverage:
+- location:
+    country:
+      id: World
+      name: World
+    level: 20
+    macroregion:
+      id: World
+      name: World
+description: Databook consolidates public statistical indicators into per-country
+  reference profiles covering 244 countries and territories, drawn from 108 openly
+  licensed datasets including World Bank WDI, WHO Global Health Observatory, UNESCO
+  UIS, UN DESA World Population Prospects and the CIA World Factbook. Each country
+  profile is organised into 15 sections and every figure is displayed with its source
+  and reference year. Browse-only, published in 25 languages.
+id: databookdataintnet
+langs:
+- id: EN
+  name: English
+- id: ES
+  name: Spanish
+- id: FR
+  name: French
+- id: DE
+  name: German
+- id: RU
+  name: Russian
+- id: ZH
+  name: Chinese
+- id: AR
+  name: Arabic
+- id: HI
+  name: Hindi
+link: https://databook.dataint.net
+name: Databook
+owner:
+  link: https://dataint.net
+  location:
+    country:
+      id: World
+      name: World
+    level: 20
+  name: DataInt
+  type: Business
+rights:
+  license_id: null
+  license_name: CC-BY
+  license_url: https://databook.dataint.net/en/licensing/
+  privacy_policy_url: null
+  rights_type: unknown
+  tos_url: null
+software:
+  id: custom
+  name: Custom software
+status: active
+tags:
+- statistics
+- indicators
+- country profiles
+- reference data
+- Databook
+topics:
+- id: SOCI
+  name: Population and society
+  type: eudatatheme
+- id: ECON
+  name: Economy and finance
+  type: eudatatheme
+- id: GOVE
+  name: Government and public sector
+  type: eudatatheme
+- id: ENVI
+  name: Environment
+  type: eudatatheme
+- id: HEAL
+  name: Health
+  type: eudatatheme
+- id: EDUC
+  name: Education, culture and sport
+  type: eudatatheme
+- id: Society
+  name: Society
+  type: iso19115
+- id: Economy
+  name: Economy
+  type: iso19115
+uid: cdi99990002

--- a/data/entities/World/indicators/logibookdataintnet.yaml
+++ b/data/entities/World/indicators/logibookdataintnet.yaml
@@ -1,0 +1,89 @@
+access_mode:
+- open
+api: false
+api_status: uncertain
+catalog_type: Indicators catalog
+content_types:
+- indicator
+- dataset
+coverage:
+- location:
+    country:
+      id: World
+      name: World
+    level: 20
+    macroregion:
+      id: World
+      name: World
+description: Logibook consolidates trade and logistics reference data into per-country
+  profiles covering 250 countries and territories, built from 98 openly licensed datasets
+  including the NGA World Port Index, OurAirports, UN/LOCODE, SMDG code lists, UNCTAD
+  liner shipping connectivity, World Bank Logistics Performance Index and CEPII BACI.
+  Country profiles break down into ports, airports, locations, trade, trade zones,
+  airlines and infrastructure, each figure shown with its source and reference year.
+  Browse-only, published in 25 languages.
+id: logibookdataintnet
+langs:
+- id: EN
+  name: English
+- id: ES
+  name: Spanish
+- id: FR
+  name: French
+- id: DE
+  name: German
+- id: RU
+  name: Russian
+- id: ZH
+  name: Chinese
+- id: AR
+  name: Arabic
+- id: HI
+  name: Hindi
+link: https://logibook.dataint.net
+name: Logibook
+owner:
+  link: https://dataint.net
+  location:
+    country:
+      id: World
+      name: World
+    level: 20
+  name: DataInt
+  type: Business
+rights:
+  license_id: null
+  license_name: null
+  license_url: https://logibook.dataint.net/en/licensing
+  privacy_policy_url: null
+  rights_type: unknown
+  tos_url: null
+software:
+  id: custom
+  name: Custom software
+status: active
+tags:
+- logistics
+- trade
+- ports
+- airports
+- indicators
+- reference data
+- Logibook
+topics:
+- id: ECON
+  name: Economy and finance
+  type: eudatatheme
+- id: TRAN
+  name: Transport
+  type: eudatatheme
+- id: INTR
+  name: International issues
+  type: eudatatheme
+- id: Economy
+  name: Economy
+  type: iso19115
+- id: Transportation
+  name: Transportation
+  type: iso19115
+uid: cdi99990003


### PR DESCRIPTION
Adds two catalog records under `data/entities/World/indicators/`.

Upfront: both sites are mine, so treat this as a proposal rather than a
straightforward contribution. If they don't fit the registry's scope, closing
this costs me nothing.

### Why `Indicators catalog`

`catalog-types.md` lists *"national indicator sites"* under this type, and
`knoemacom.yaml` is already registered with a similar profile — a site that
consolidates indicators from official sources rather than publishing its own.
That seemed like the closest fit. If **Datasets list** or **Other** is more
accurate, say so and I'll move them.

### The records

- **Databook** — 244 countries and territories, built from 108 openly licensed
  datasets (World Bank WDI, WHO GHO, UNESCO UIS, UN DESA WPP, CIA World
  Factbook). 15 sections per country; every figure carries its source and
  reference year.
- **Logibook** — the trade and logistics side: 250 countries, 98 datasets
  (NGA World Port Index, OurAirports, UN/LOCODE, SMDG code lists, UNCTAD LSCI,
  World Bank LPI, CEPII BACI). Seven verticals per country — ports, airports,
  locations, trade, trade zones, airlines, infrastructure.

Both are free, no registration, no subscription; they run on ads. Published in
25 languages.

### What they are not

`api: false` on both, and `api_status: uncertain` — there is no API, no SDMX
endpoint and no bulk download, so nothing here is harvestable. I noticed
`aidsinfounaidsorg`, `asbopecorg` and `asticgiarorg` are also `api: false`, so
I took it that browse-only entries are still in scope; if the registry is
tightening toward harvestable sources only, that's a fair reason to decline.

I also don't produce primary data — these consolidate existing public sources
and present them readably, with provenance shown per value.

### Process followed

- `uid` assigned via `python scripts/builder.py assign` (not invented) →
  `cdi99990002`, `cdi99990003`
- `validate-yaml --id` passes for both, 0 errors
- `coverage` populated, so `MISSING_COVERAGE` shouldn't fire
- No other files touched — `assign` scanned everything but only wrote these two

Counts above were read off the live pages today, not estimated. Happy to adjust
any field to house style.
