### PR TITLE
Update BaanScope Open Data (TH): eight cuts, four of them public-register joins

### DIFF
--- a/data/entities/TH/Federal/opendata/baanscopecom.yaml
+++ b/data/entities/TH/Federal/opendata/baanscopecom.yaml
@@ -17,13 +17,13 @@ coverage:
 description: Aggregate open datasets derived from BaanScope's tracked pipeline of new-build
   residential projects by Thailand's nine largest SET-listed developers. Eight cuts are
   published, each with a column dictionary. Four cover the pipeline itself, by Bangkok-metro
-  district, by developer, by completion year and by rail line. Four join it to public
-  registers: the Bangkok city plan (floor area ratio in force per land-use class, and what the
-  March 2026 draft plan would change), the national ONEP environmental register (filings
-  approved and still recorded as not started), the city drainage department's monitored flood
-  points, and OpenStreetMap amenities within 800 metres. Files are served as CSV and JSON under
-  CC BY 4.0 with permissive CORS headers, need no sign-up or API key, and are regenerated on
-  every site build.
+  district, by developer, by completion year and by rail line. Four more join it to public
+  registers. Those are the Bangkok city plan (floor area ratio in force per land-use class, and
+  what the March 2026 draft plan would change), the national ONEP environmental register
+  (filings approved and still recorded as not started), the city drainage department's
+  monitored flood points, and OpenStreetMap amenities within 800 metres. Files are served as
+  CSV and JSON under CC BY 4.0 with permissive CORS headers, need no sign-up or API key, and
+  are regenerated on every site build.
 id: baanscopecom
 langs:
 - id: EN

--- a/data/entities/TH/Federal/opendata/baanscopecom.yaml
+++ b/data/entities/TH/Federal/opendata/baanscopecom.yaml
@@ -15,10 +15,15 @@ coverage:
       id: '035'
       name: South-eastern Asia
 description: Aggregate open datasets derived from BaanScope's tracked pipeline of new-build
-  residential projects by Thailand's nine largest SET-listed developers. Three cuts are
-  published, by Bangkok-metro district, by developer and by completion year, each with a
-  column dictionary. Files are served as CSV and JSON under CC BY 4.0 with permissive CORS
-  headers, need no sign-up or API key, and are regenerated on every site build.
+  residential projects by Thailand's nine largest SET-listed developers. Eight cuts are
+  published, each with a column dictionary. Four cover the pipeline itself, by Bangkok-metro
+  district, by developer, by completion year and by rail line. Four join it to public
+  registers: the Bangkok city plan (floor area ratio in force per land-use class, and what the
+  March 2026 draft plan would change), the national ONEP environmental register (filings
+  approved and still recorded as not started), the city drainage department's monitored flood
+  points, and OpenStreetMap amenities within 800 metres. Files are served as CSV and JSON under
+  CC BY 4.0 with permissive CORS headers, need no sign-up or API key, and are regenerated on
+  every site build.
 id: baanscopecom
 langs:
 - id: EN
@@ -58,6 +63,9 @@ tags:
 - construction
 - property
 - bangkok
+- urban planning
+- zoning
+- environment
 - thailand
 - open data
 topics:


### PR DESCRIPTION
Updates the `baanscopecom` record merged in #103. The description said three cuts; there are now eight, and four of them join the catalogue to public registers, which changes what the catalog is useful for.

**Description:** three cuts becomes eight. The four new ones are the Bangkok city plan (floor area ratio in force per land-use class, and what the March 2026 draft plan would change), the national ONEP environmental register (filings approved and still recorded as not started), the city drainage department's monitored flood points, and OpenStreetMap amenities within 800 metres. The `rail-lines` cut, which also postdates the original record, is now named too.

**Tags:** adds `urban planning`, `zoning` and `environment`.

**Unchanged:** `link`, `catalog_type`, `access_mode`, `rights`, `owner`, `coverage`, `langs`, `software`, `status`. Same URL, same CC BY 4.0 licence, same CORS headers, same no-sign-up access, same regeneration on every site build.

Checked live before opening: all sixteen download URLs return 200, and each joined dataset credits its upstream register on the page, in the JSON envelope and in `isBasedOn` on the JSON-LD.